### PR TITLE
ci: must pass the commit ID via github actions

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -43,6 +43,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{  github.ref_name }}
           file: images/Dockerfile
+          build-args:
+            - git_sha=${{ github.event.pull_request.head.sha }}
 
       - name: Install the j2 dependency
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
**What this PR does / why we need it**:
We were only passing the git commit SHA via the makefile, and we are
building the image via a github action.
    
This commit addresses this, by passing the commit SHA to the github
action as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #75 

**Special notes for your reviewer** *(optional)*:

