### PR TITLE
ci: pass the commit ID via github actions also for `latest-amd64`

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -34,6 +34,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest-amd64
           file: images/Dockerfile
+          build-args: |
+            git_sha=${{ github.event.pull_request.head.sha }}
 
       - name: Push stable container image
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
**What this PR does / why we need it**:
We were only passing the git commit id for tagged images. 

This feature is most useful for the `latest` tagged image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 

**Special notes for your reviewer** *(optional)*:

