### PR TITLE
build, ci: embed the git commit id via GITHUB_ENV

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -15,6 +15,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Version Check
+        run: |
+          echo "git_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -35,7 +39,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest-amd64
           file: images/Dockerfile
           build-args: |
-            git_sha=${{ github.event.pull_request.head.sha }}
+            git_sha=${{ env.git_commit_hash }}
 
       - name: Push stable container image
         if: startsWith(github.ref, 'refs/tags/')
@@ -46,7 +50,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{  github.ref_name }}
           file: images/Dockerfile
           build-args: |
-            git_sha=${{ github.event.pull_request.head.sha }}
+            git_sha=${{ env.git_commit_hash }}
 
       - name: Install the j2 dependency
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems now we are indeed labeling the image via the build args, but we are failing to get the correct value; this is what I get currently:

```bash
skopeo inspect docker://ghcr.io/k8snetworkplumbingwg/multus-dynamic-networks-controller:latest-amd64 -f '{{ index .Labels "multi.GIT_SHA" }}'

```
This means the value of `github.event.pull_request.head.sha` is an empty string.

This PR uses github env instead to pass the values along to the image builder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

