### PR TITLE
Level driven controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ listening to pod's network selection elements (i.e. the pod `k8s.v1.cni.cncf.io/
 change (adding / removing network selection elements), it will invoke the corresponding delegate effectively adding
 (or removing) a network interface to a running pod.
 
+The controller provides a reconciliation loop between the desired state (the network selection elements), and the
+current state (the network status); in order for it to work, all the attachments featured in the desired state **must**
+feature interface names. If they don't, the user should patch up the pod's network selection elements, adding it the
+name of the interface for each respective attachment.
+
 Please refer to the
 [multus-cni docs](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/quickstart.md#creating-a-pod-that-attaches-an-additional-interface)
 for more information on how additional interfaces are added to a pod.
@@ -164,5 +169,4 @@ e1db8da3c6267b3c2a5aca72ef8dd6a10b0ec9fd
 ```
 
 ## Known limitations
-- the pod controller is not [level driven](https://stackoverflow.com/questions/1966863/level-vs-edge-trigger-network-event-mechanisms). This is tracked in this [RFE](https://github.com/maiqueb/multus-dynamic-networks-controller/issues/48).
 - plug / unplug interfaces to networks requiring device-plugin interaction. We must investigate this further; an RFE **may** be opened once we have the required data.

--- a/pkg/annotations/dynamic-network-status_test.go
+++ b/pkg/annotations/dynamic-network-status_test.go
@@ -212,7 +212,35 @@ var _ = Describe("NetworkStatusFromResponse", func() {
 			attachmentInfo{
 				ifaceName:   "iface2",
 				networkName: "net2",
-			}))
+			}),
+		Entry(
+			"the default interface is reported when we delete another interface",
+			[]nadv1.NetworkStatus{
+				{
+					Name:      annotations.NamespacedName(namespace, networkName),
+					Interface: "iface1",
+					Mac:       "00:00:00:20:10:00",
+					Default:   true,
+				},
+				{
+					Name:      annotations.NamespacedName(namespace, "net2"),
+					Interface: "iface2",
+					Mac:       "aa:bb:cc:20:10:00",
+				},
+			},
+			[]nadv1.NetworkStatus{
+				{
+					Name:      annotations.NamespacedName(namespace, networkName),
+					Interface: "iface1",
+					Mac:       "00:00:00:20:10:00",
+					Default:   true,
+				},
+			},
+			attachmentInfo{
+				ifaceName:   "iface2",
+				networkName: "net2",
+			},
+		))
 })
 
 func newPod(podName string, namespace string, netStatus ...nadv1.NetworkStatus) *corev1.Pod {

--- a/pkg/annotations/dynamic-network-status_test.go
+++ b/pkg/annotations/dynamic-network-status_test.go
@@ -30,8 +30,10 @@ var _ = Describe("NetworkStatusFromResponse", func() {
 		Expect(
 			AddDynamicIfaceToStatus(
 				newPod(podName, namespace, initialNetStatus...),
-				newNetworkSelectionElementWithIface(networkName, ifaceName, namespace),
-				newResponse(ifaceToAdd, macAddr, resultIPs...),
+				*NewAttachmentResult(
+					newNetworkSelectionElementWithIface(networkName, ifaceName, namespace),
+					newResponse(ifaceToAdd, macAddr, resultIPs...),
+				),
 			),
 		).To(Equal(expectedNetworkStatus))
 	},

--- a/pkg/annotations/network-selection-elements_test.go
+++ b/pkg/annotations/network-selection-elements_test.go
@@ -1,4 +1,4 @@
-package annotations
+package annotations_test
 
 import (
 	"strings"
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pkg/annotations"
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
@@ -19,17 +20,17 @@ var _ = Describe("Parsing annotations", func() {
 	const namespace = "ns1"
 
 	It("nil input", func() {
-		_, err := ParsePodNetworkAnnotations("", namespace)
+		_, err := annotations.ParsePodNetworkAnnotations("", namespace)
 		Expect(err).To(MatchError("parsePodNetworkAnnotation: pod annotation does not have \"network\" as key"))
 	})
 
 	It("empty list input", func() {
-		Expect(ParsePodNetworkAnnotations("[]", namespace)).To(BeEmpty())
+		Expect(annotations.ParsePodNetworkAnnotations("[]", namespace)).To(BeEmpty())
 	})
 
 	It("single network name", func() {
 		const networkName = "net1"
-		Expect(ParsePodNetworkAnnotations(networkName, namespace)).To(ConsistOf(newNetworkSelectionElement(networkName, namespace)))
+		Expect(annotations.ParsePodNetworkAnnotations(networkName, namespace)).To(ConsistOf(newNetworkSelectionElement(networkName, namespace)))
 	})
 
 	It("comma separated list of network names", func() {
@@ -38,7 +39,7 @@ var _ = Describe("Parsing annotations", func() {
 			secondNetworkName = "net321"
 		)
 		Expect(
-			ParsePodNetworkAnnotations(networkSelectionElements(networkName, secondNetworkName), namespace),
+			annotations.ParsePodNetworkAnnotations(networkSelectionElements(networkName, secondNetworkName), namespace),
 		).To(
 			ConsistOf(
 				newNetworkSelectionElement(networkName, namespace),
@@ -51,7 +52,7 @@ var _ = Describe("Parsing annotations", func() {
 			secondNetworkAndInterfaceNamingPair = "net321@eth2"
 		)
 		Expect(
-			ParsePodNetworkAnnotations(
+			annotations.ParsePodNetworkAnnotations(
 				networkSelectionElements(
 					networkAndInterfaceNamingPair,
 					secondNetworkAndInterfaceNamingPair),
@@ -65,7 +66,7 @@ var _ = Describe("Parsing annotations", func() {
 	It("network selection element specified in JSON", func() {
 		const networkSelectionElementsString = "[\n            { \"name\" : \"macvlan-conf-1\" },\n            { \"name\" : \"macvlan-conf-2\", \"interface\": \"ens4\" }\n    ]"
 		Expect(
-			ParsePodNetworkAnnotations(networkSelectionElementsString, namespace),
+			annotations.ParsePodNetworkAnnotations(networkSelectionElementsString, namespace),
 		).To(
 			ConsistOf(
 				newNetworkSelectionElement("macvlan-conf-1", namespace),

--- a/pkg/annotations/types.go
+++ b/pkg/annotations/types.go
@@ -1,0 +1,18 @@
+package annotations
+
+import (
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	multusapi "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api"
+)
+
+type AttachmentResult struct {
+	attachment *nadv1.NetworkSelectionElement
+	result     *multusapi.Response
+}
+
+func NewAttachmentResult(attachment *nadv1.NetworkSelectionElement, result *multusapi.Response) *AttachmentResult {
+	return &AttachmentResult{
+		attachment: attachment,
+		result:     result,
+	}
+}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -154,7 +154,7 @@ func (pnc *PodNetworksController) processNextWorkItem() bool {
 	}
 
 	indexedNetworkSelectionElements := annotations.IndexPodNetworkSelectionElements(pod)
-	indexedNetworkStatus := annotations.IndexNetworkStatus(pod)
+	indexedNetworkStatus := annotations.IndexNetworkStatusIgnoringDefaultNetwork(pod)
 
 	netnsPath, err := pnc.netnsPath(pod)
 	if err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -192,7 +191,7 @@ func (pnc *PodNetworksController) handlePodUpdate(oldObj interface{}, newObj int
 		remove DynamicAttachmentRequestType = "remove"
 	)
 
-	if reflect.DeepEqual(oldPod.Annotations, newPod.Annotations) {
+	if !didNetworkSelectionElementsChange(oldPod, newPod) {
 		return
 	}
 	podNamespace := oldPod.GetNamespace()
@@ -472,4 +471,15 @@ func serializeNetAttachDefWithDefaults(netAttachDef *nadv1.NetworkAttachmentDefi
 		)
 	}
 	return netAttachDefWithDefaults, nil
+}
+
+func didNetworkSelectionElementsChange(oldPod *corev1.Pod, newPod *corev1.Pod) bool {
+	oldNetworkSelectionElementsString, didPodHaveExtraAttachments := oldPod.Annotations[nadv1.NetworkAttachmentAnnot]
+	newNetworkSelectionElementsString, doesPodHaveExtraAttachmentsNow := newPod.Annotations[nadv1.NetworkAttachmentAnnot]
+
+	if didPodHaveExtraAttachments != doesPodHaveExtraAttachmentsNow ||
+		oldNetworkSelectionElementsString != newNetworkSelectionElementsString {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -275,7 +275,10 @@ func (pnc *PodNetworksController) addNetworks(dynamicAttachmentRequest *DynamicA
 		}
 		klog.Infof("response: %v", *response.Result)
 
-		newIfaceStatus, err := annotations.AddDynamicIfaceToStatus(pod, netToAdd, response)
+		newIfaceStatus, err := annotations.AddDynamicIfaceToStatus(
+			pod,
+			*annotations.NewAttachmentResult(netToAdd, response),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to compute the updated network status: %v", err)
 		}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Dynamic Attachment controller", func() {
 					if err != nil {
 						return nil
 					}
-					status, err := networkStatus(updatedPod.Annotations)
+					status, err := annotations.PodDynamicNetworkStatus(updatedPod)
 					if err != nil {
 						return nil
 					}
@@ -157,7 +157,7 @@ var _ = Describe("Dynamic Attachment controller", func() {
 						if err != nil {
 							return nil, err
 						}
-						status, err := networkStatus(updatedPod.Annotations)
+						status, err := annotations.PodDynamicNetworkStatus(updatedPod)
 						if err != nil {
 							return nil, err
 						}
@@ -194,7 +194,7 @@ var _ = Describe("Dynamic Attachment controller", func() {
 						if err != nil {
 							return nil, err
 						}
-						status, err := networkStatus(updatedPod.Annotations)
+						status, err := annotations.PodDynamicNetworkStatus(updatedPod)
 						if err != nil {
 							return nil, err
 						}

--- a/pkg/multuscni/fake/client.go
+++ b/pkg/multuscni/fake/client.go
@@ -25,9 +25,10 @@ func NewFakeClient(currentStatus ...NetworkConfig) *Client {
 }
 
 func (fc *Client) InvokeDelegate(multusRequest *multusapi.Request) (*multusapi.Response, error) {
-	serverReply, wasFound := fc.requestData[key(multusRequest)]
+	ifaceKey := key(multusRequest)
+	serverReply, wasFound := fc.requestData[ifaceKey]
 	if !wasFound {
-		return nil, fmt.Errorf("not found")
+		return nil, fmt.Errorf("not found: %s", ifaceKey)
 	}
 	return serverReply, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-write the controller as level driven, instead of edge-triggered.

This makes user interaction more resilient, since the controller will try to materialize the desired state (network-selection-elements) into the current state (network-status).

There is one behavior that needs to be highlighted: the existing interfaces need to always feature the interface name in the desired state (network selection elements); take the following example:
- initially, there is a secondary interface in the pod for which the user did not name explicitly.
  - at t=1, the user attempts to hotplug interfaces; these will fail
  - at t=2, the user corrects the desired state, manually specifying the name of the interface for the existing attachment
  - the controller will reconcile the pod state, and will now be able to hotplug the new interfaces, specified at t=2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #48
Fixes #66


**Special notes for your reviewer** *(optional)*:
Depends-on: #46 

