### PR TITLE
multus: liveness check multus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ NAMESPACE ?= kube-system
 
 CONTAINERD_SOCKET_PATH ?= "/run/containerd/containerd.sock"
 CRIO_SOCKET_PATH ?= "/run/crio/crio.sock"
+MULTUS_SOCKET_PATH ?= "/run/multus/multus.sock"
 
 GIT_SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 
@@ -25,8 +26,8 @@ img-build: build test
 	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f images/Dockerfile --build-arg git_sha=$(GIT_SHA) .
 
 manifests:
-	IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CONTAINERD_SOCKET_PATH} NAMESPACE=${NAMESPACE} hack/generate_manifests.sh
-	CRIO_RUNTIME="yes" IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CRIO_SOCKET_PATH} NAMESPACE=${NAMESPACE} hack/generate_manifests.sh
+	MULTUS_SOCKET_PATH=${MULTUS_SOCKET_PATH} IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CONTAINERD_SOCKET_PATH} NAMESPACE=${NAMESPACE} hack/generate_manifests.sh
+	CRIO_RUNTIME="yes" MULTUS_SOCKET_PATH=${MULTUS_SOCKET_PATH} IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CRIO_SOCKET_PATH} NAMESPACE=${NAMESPACE} hack/generate_manifests.sh
 
 test:
 	$(GO) test -v ./pkg/...

--- a/hack/generate_manifests.sh
+++ b/hack/generate_manifests.sh
@@ -8,15 +8,16 @@ templates_dir="$ROOT/templates"
 for file in `ls $templates_dir/`; do
 	echo $file
 	if [ -z $CRIO_RUNTIME ]; then
-	  j2 -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/${file%.j2}"
+	  j2 -e MULTUS_SOCKET_PATH -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/${file%.j2}"
 	else
 	  if [ $file != "dynamic-networks-controller.yaml.j2" ]; then
 	    continue
 	  fi
-	  j2 -e CRIO_RUNTIME -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/crio-${file%.j2}"
+	  j2 -e MULTUS_SOCKET_PATH -e CRIO_RUNTIME -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/crio-${file%.j2}"
 	fi
 done
 unset IMAGE_REGISTRY
 unset IMAGE_TAG
 unset CRI_SOCKET_PATH
 unset NAMESPACE
+unset MULTUS_SOCKET_PATH

--- a/manifests/crio-dynamic-networks-controller.yaml
+++ b/manifests/crio-dynamic-networks-controller.yaml
@@ -106,6 +106,16 @@ spec:
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"
             - "-v=5"
+          livenessProbe:
+            exec:
+                command:
+                - curl
+                - --fail
+                - --unix-socket
+                - /host/run/multus/multus.sock
+                - localhost/healthz
+            initialDelaySeconds: 15
+            periodSeconds: 5
           resources:
             requests:
               cpu: "100m"

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -105,6 +105,16 @@ spec:
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"
             - "-v=5"
+          livenessProbe:
+            exec:
+                command:
+                - curl
+                - --fail
+                - --unix-socket
+                - /host/run/multus/multus.sock
+                - localhost/healthz
+            initialDelaySeconds: 15
+            periodSeconds: 5
           resources:
             requests:
               cpu: "100m"

--- a/templates/dynamic-networks-controller.yaml.j2
+++ b/templates/dynamic-networks-controller.yaml.j2
@@ -65,7 +65,7 @@ data:
         "criType": "crio",
         {%- endif %}
         "criSocketPath": "/host{{ CRI_SOCKET_PATH }}",
-        "multusSocketPath": "/host/run/multus/multus.sock"
+        "multusSocketPath": "/host{{ MULTUS_SOCKET_PATH }}"
     }
 ---
 apiVersion: apps/v1
@@ -108,6 +108,16 @@ spec:
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"
             - "-v=5"
+          livenessProbe:
+            exec:
+                command:
+                - curl
+                - --fail
+                - --unix-socket
+                - /host{{ MULTUS_SOCKET_PATH }}
+                - localhost/healthz
+            initialDelaySeconds: 15
+            periodSeconds: 5
           resources:
             requests:
               cpu: "100m"
@@ -119,7 +129,7 @@ spec:
               mountPath: /etc/dynamic-networks-controller/
               readOnly: true
             - name: multus-server-socket
-              mountPath: /host/run/multus/multus.sock
+              mountPath: /host{{ MULTUS_SOCKET_PATH }}
             - name: cri-socket
               mountPath: /host{{ CRI_SOCKET_PATH }}
       terminationGracePeriodSeconds: 10
@@ -132,7 +142,7 @@ spec:
                 path: dynamic-networks-config.json
         -  name: multus-server-socket
            hostPath:
-             path: /run/multus/multus.sock
+             path: {{ MULTUS_SOCKET_PATH }}
              type: Socket
         -  name: cri-socket
            hostPath:


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

**What this PR does / why we need it**:
This PR adds a liveness probe to the controller; it continuously queries the multus-cni `healthz` endpoint, and restarts the controller pods whenever it fails to contact the multus API.

With this, we ensure the controller always has access to the correct multus socket to contact the multus server API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #96 

**Special notes for your reviewer** *(optional)*:
Multus-cni was added the `healthz` endpoint in https://github.com/k8snetworkplumbingwg/multus-cni/pull/963 
