### PR TITLE
dependabot: ignore k8s dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,5 @@ updates:
       interval: "weekly"
     assignees:
       - maiqueb
+    ignore:
+      - dependency-name: "k8s.io/*"


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubernetes dependencies should be updated on demand.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

