### PR TITLE
build, ci, test: bump to golang 1.19

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build
       run: time make build
@@ -31,7 +31,7 @@ jobs:
     - name: Linters
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.47.3
+        version: v1.48.0
         args: --timeout 3m --verbose cmd/... pkg/...
 
     - name: Test

--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Setup kind cluster
         run: hack/e2e-kind-cluster-setup.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
 
-go 1.18
+go 1.19
 
 require (
 	github.com/containerd/containerd v1.6.14

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.18 as builder
+FROM quay.io/projectquay/golang:1.19 as builder
 ENV GOPATH=/go
 RUN mkdir -p $GOPATH/src/github.com/maiqueb/multus-dynamic-networks-controller
 WORKDIR $GOPATH/src/github.com/maiqueb/multus-dynamic-networks-controller

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -52,7 +51,7 @@ var _ = Describe("Dynamic Attachment controller", func() {
 			)
 
 			var err error
-			cniConfigDir, err = ioutil.TempDir("", "multus-config")
+			cniConfigDir, err = os.MkdirTemp("", "multus-config")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(os.MkdirAll(cniConfigDir, configFilePermissions)).To(Succeed())
 			Expect(os.WriteFile(


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

**What this PR does / why we need it**:
This PR bumps the golang version to 1.19.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

