### PR TITLE
E2e bump timeouts

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			})
 		})
 
-		Context("a provisioned pod whose network selection elements do not feature the inteface name", func() {
+		Context("a provisioned pod whose network selection elements do not feature the interface name", func() {
 			const (
 				ifaceToAdd = "ens58"
 				macAddress = "02:03:04:05:06:07"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			const (
 				ifaceToAdd = "ens58"
 				macAddress = "02:03:04:05:06:07"
-				timeout    = 2 * time.Second
+				timeout    = 5 * time.Second
 			)
 
 			var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes 2 seconds can be not enough on CI to reconcile the attachments
for a pod when a pod does not feature the interface names; also, this timeout
is also used for a `Consistently` clause, where 2 seconds is also too little.
    
Thus, let's give it some more time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #124 

**Special notes for your reviewer** *(optional)*:

