### PR TITLE
ci, e2e tests: override the multus daemonset spec

### DIFF
--- a/hack/e2e-kind-cluster-setup.sh
+++ b/hack/e2e-kind-cluster-setup.sh
@@ -12,7 +12,7 @@ setup_cluster() {
     trap "popd" RETURN SIGINT
     ./get_tools.sh
     CNI_VERSION="$CNI_VERSION" ./generate_yamls.sh
-    OCI_BIN="$OCI_BIN" ./setup_cluster.sh
+    OCI_BIN="$OCI_BIN" MULTUS_MANIFEST="multus-daemonset-thick.yml" ./setup_cluster.sh
 }
 
 push_local_image() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We must override the multus daemonset spec, otherwise, we end up with the "thin" version, which does not react to dynamic pod interface requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

