### PR TITLE
Fix e2e tests on crio providers

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -62,6 +62,14 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			})
 		}
 
+		isTestNamespaceEmpty := func() bool {
+			pods, err := clients.ListPods(namespace, appLabel(podName))
+			if err != nil {
+				return false
+			}
+			return len(pods.Items) == 0
+		}
+
 		Context("a provisioned pod having network selection elements", func() {
 			var pod *corev1.Pod
 
@@ -93,6 +101,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 
 			AfterEach(func() {
 				Expect(clients.DeletePod(pod)).To(Succeed())
+				Eventually(isTestNamespaceEmpty, timeout).Should(BeTrue())
 			})
 
 			It("manages to add a new interface to a running pod", func() {
@@ -190,6 +199,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 
 			AfterEach(func() {
 				Expect(clients.DeletePod(pod)).To(Succeed())
+				Eventually(isTestNamespaceEmpty, timeout).Should(BeTrue())
 			})
 
 			It("manages to add a new interface to a running pod", func() {
@@ -267,6 +277,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 
 			AfterEach(func() {
 				Expect(clients.DeletePod(pod)).To(Succeed())
+				Eventually(isTestNamespaceEmpty, timeout).Should(BeTrue())
 			})
 
 			runningPod := func() *corev1.Pod {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 
 				It("can be hot unplugged from a running pod", func() {
 					const ifaceToRemove = ifaceToAddWithIPAM
-					pods, err := clients.ListPods(namespace, fmt.Sprintf("app=%s", podName))
+					pods, err := clients.ListPods(namespace, appLabel(podName))
 					Expect(err).NotTo(HaveOccurred())
 					pod = &pods.Items[0]
 
@@ -270,7 +270,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			})
 
 			runningPod := func() *corev1.Pod {
-				pods, err := clients.ListPods(namespace, fmt.Sprintf("app=%s", podName))
+				pods, err := clients.ListPods(namespace, appLabel(podName))
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 				ExpectWithOffset(1, pods.Items).NotTo(BeEmpty())
 				return &pods.Items[0]
@@ -418,4 +418,8 @@ func lowerDeviceName() string {
 		return lowerDeviceIfaceName
 	}
 	return defaultLowerDeviceIfaceName
+}
+
+func appLabel(appName string) string {
+	return fmt.Sprintf("app=%s", appName)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 		namespace   = "ns1"
 		networkName = "tenant-network"
 		podName     = "tiny-winy-pod"
+		timeout     = 5 * time.Second
 	)
 	var clients *client.E2EClient
 
@@ -102,7 +103,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 					Namespace:        namespace,
 					InterfaceRequest: ifaceToAdd,
 				})).To(Succeed())
-				Eventually(filterPodNonDefaultNetworks).Should(
+				Eventually(filterPodNonDefaultNetworks, timeout).Should(
 					WithTransform(
 						status.CleanMACAddressesFromStatus(),
 						ConsistOf(
@@ -117,7 +118,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 				const ifaceToRemove = initialPodIfaceName
 
 				Expect(clients.RemoveNetworkFromPod(pod, networkName, namespace, ifaceToRemove)).To(Succeed())
-				Eventually(filterPodNonDefaultNetworks).Should(BeEmpty())
+				Eventually(filterPodNonDefaultNetworks, timeout).Should(BeEmpty())
 			})
 
 			Context("a network with IPAM", func() {
@@ -143,7 +144,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 				})
 
 				It("can be hotplugged into a running pod", func() {
-					Eventually(filterPodNonDefaultNetworks).Should(
+					Eventually(filterPodNonDefaultNetworks, timeout).Should(
 						ContainElements(
 							nettypes.NetworkStatus{
 								Name:      namespacedName(namespace, ipamNetworkToAdd),
@@ -161,7 +162,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 					pod = &pods.Items[0]
 
 					Expect(clients.RemoveNetworkFromPod(pod, networkName, namespace, ifaceToRemove)).To(Succeed())
-					Eventually(filterPodNonDefaultNetworks).Should(
+					Eventually(filterPodNonDefaultNetworks, timeout).Should(
 						Not(ContainElements(
 							nettypes.NetworkStatus{
 								Name:      namespacedName(namespace, ipamNetworkToAdd),
@@ -203,7 +204,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 					InterfaceRequest: ifaceToAdd,
 					MacRequest:       desiredMACAddr,
 				})).To(Succeed())
-				Eventually(filterPodNonDefaultNetworks).Should(
+				Eventually(filterPodNonDefaultNetworks, timeout).Should(
 					ConsistOf(
 						nettypes.NetworkStatus{
 							Name:      namespacedName(namespace, networkName),
@@ -217,7 +218,6 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			const (
 				ifaceToAdd = "ens58"
 				macAddress = "02:03:04:05:06:07"
-				timeout    = 5 * time.Second
 			)
 
 			var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses failing e2e tests on kubevirtci providers.

It increases the timeouts a little bit, but the most important thing it does is ensure all pods are gone between tests, since the error we were seeing was a statically defined mac address being already used (which means the previous pod using it, is not yet deleted).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #140

**Special notes for your reviewer** *(optional)*:

