### PR TITLE
manifests: Update Multus socket path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE ?= kube-system
 
 CONTAINERD_SOCKET_PATH ?= "/run/containerd/containerd.sock"
 CRIO_SOCKET_PATH ?= "/run/crio/crio.sock"
-MULTUS_SOCKET_PATH ?= "/run/multus/multus.sock"
+MULTUS_SOCKET_PATH ?= "/run/multus/socket/multus.sock"
 
 GIT_SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 

--- a/manifests/crio-dynamic-networks-controller.yaml
+++ b/manifests/crio-dynamic-networks-controller.yaml
@@ -63,7 +63,7 @@ data:
     {
         "criType": "crio",
         "criSocketPath": "/host/run/crio/crio.sock",
-        "multusSocketPath": "/host/run/multus/multus.sock"
+        "multusSocketPath": "/host/run/multus/socket/multus.sock"
     }
 ---
 apiVersion: apps/v1
@@ -112,7 +112,7 @@ spec:
                 - curl
                 - --fail
                 - --unix-socket
-                - /host/run/multus/multus.sock
+                - /host/run/multus/socket/multus.sock
                 - localhost/healthz
             initialDelaySeconds: 15
             periodSeconds: 5
@@ -127,7 +127,7 @@ spec:
               mountPath: /etc/dynamic-networks-controller/
               readOnly: true
             - name: multus-server-socket
-              mountPath: /host/run/multus/multus.sock
+              mountPath: /host/run/multus/socket/multus.sock
             - name: cri-socket
               mountPath: /host/run/crio/crio.sock
       terminationGracePeriodSeconds: 10
@@ -140,7 +140,7 @@ spec:
                 path: dynamic-networks-config.json
         -  name: multus-server-socket
            hostPath:
-             path: /run/multus/multus.sock
+             path: /run/multus/socket/multus.sock
              type: Socket
         -  name: cri-socket
            hostPath:

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -62,7 +62,7 @@ data:
   dynamic-networks-config.json: |
     {
         "criSocketPath": "/host/run/containerd/containerd.sock",
-        "multusSocketPath": "/host/run/multus/multus.sock"
+        "multusSocketPath": "/host/run/multus/socket/multus.sock"
     }
 ---
 apiVersion: apps/v1
@@ -111,7 +111,7 @@ spec:
                 - curl
                 - --fail
                 - --unix-socket
-                - /host/run/multus/multus.sock
+                - /host/run/multus/socket/multus.sock
                 - localhost/healthz
             initialDelaySeconds: 15
             periodSeconds: 5
@@ -126,7 +126,7 @@ spec:
               mountPath: /etc/dynamic-networks-controller/
               readOnly: true
             - name: multus-server-socket
-              mountPath: /host/run/multus/multus.sock
+              mountPath: /host/run/multus/socket/multus.sock
             - name: cri-socket
               mountPath: /host/run/containerd/containerd.sock
       terminationGracePeriodSeconds: 10
@@ -139,7 +139,7 @@ spec:
                 path: dynamic-networks-config.json
         -  name: multus-server-socket
            hostPath:
-             path: /run/multus/multus.sock
+             path: /run/multus/socket/multus.sock
              type: Socket
         -  name: cri-socket
            hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
In OKD 4.14, the Multus socket is located at the following path: `/run/multus/socket/multus.sock`

Update the example manifest accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

