### PR TITLE
Controller: Set CNI args on the delegate request

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Linters
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.48.0
+        version: v1.54.2
         args: --timeout 3m --verbose cmd/... pkg/...
 
     - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters:
   enable:
     - bodyclose
     - deadcode
-    - depguard
     - dogsled
     - dupl
     - errcheck


### PR DESCRIPTION
**What this PR does / why we need it**:
The CNI args has to be set in the delegate request so the cni-args in the network attachment annotation are considered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

