### PR TITLE
e2e: parametrize the test number of repetitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ CONTAINERD_SOCKET_PATH ?= "/run/containerd/containerd.sock"
 CRIO_SOCKET_PATH ?= "/run/crio/crio.sock"
 MULTUS_SOCKET_PATH ?= "/run/multus/multus.sock"
 
+NUMBER_OF_TIMES ?= 1
+
 GIT_SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 
 .PHONY: manifests
@@ -33,4 +35,4 @@ test:
 	$(GO) test -v ./pkg/...
 
 e2e/test:
-	$(GO) test -v -count=1 ./e2e/...
+	$(GO) test -v -count=$(NUMBER_OF_TIMES) ./e2e/...


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the number of e2e test repetitions to be defined by the user when running locally the e2e tests.

The user should: `NUMBER_OF_TIMES=20 make e2e/test` to have 20 repetitions of the test framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

