### PR TITLE
e2e: read the value of the HOME env var

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -309,7 +309,8 @@ func clusterConfig() (*rest.Config, error) {
 
 	kubeconfigPath, found := os.LookupEnv(kubeconfig)
 	if !found {
-		kubeconfigPath = "$HOME/.kube/config"
+		homePath := os.Getenv("HOME")
+		kubeconfigPath = fmt.Sprintf("%s/.kube/config", homePath)
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reads the HOME variable from the environment, thus allowing the e2e test framework to properly default the path to the kubeconfig.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

