### PR TITLE
ci: bump setup-python github action version

### DIFF
--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -10,7 +10,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the setup-python version to v4, thus removing the following warning from CI:
```
e2e-tests
The following actions uses node12 which is deprecated and will be forced to run
on node16: actions/setup-python@v2.
```

Link to a failure:
https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/actions/runs/6416838930

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

