### PR TITLE
fix: Replace j2cli with jinjanator in GitHub workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,8 @@ jobs:
         python-version: 3.x
 
     - run: |
-        pip3 install --user --upgrade j2cli
+        pip3 install --user --upgrade jinjanator
+        ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
         j2 --version
 
     - uses: actions/checkout@v3

--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -15,7 +15,8 @@ jobs:
           python-version: 3.x
 
       - run: |
-          pip3 install --user --upgrade j2cli
+          pip3 install --user --upgrade jinjanator
+          ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
           j2 --version
 
       - uses: actions/checkout@v3

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: Install the j2 dependency
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          pip3 install --user --upgrade j2cli
+          pip3 install --user --upgrade jinjanator
+          ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
           j2 --version
 
       - name: Template release manifests

--- a/hack/generate_manifests.sh
+++ b/hack/generate_manifests.sh
@@ -8,12 +8,12 @@ templates_dir="$ROOT/templates"
 for file in `ls $templates_dir/`; do
 	echo $file
 	if [ -z $CRIO_RUNTIME ]; then
-	  j2 -e MULTUS_SOCKET_PATH -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/${file%.j2}"
+	  j2 ${templates_dir}/$file -o "manifests/${file%.j2}"
 	else
 	  if [ $file != "dynamic-networks-controller.yaml.j2" ]; then
 	    continue
 	  fi
-	  j2 -e MULTUS_SOCKET_PATH -e CRIO_RUNTIME -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o "manifests/crio-${file%.j2}"
+	  j2  ${templates_dir}/$file -o "manifests/crio-${file%.j2}"
 	fi
 done
 unset IMAGE_REGISTRY


### PR DESCRIPTION
**What this PR does / why we need it**:

j2cli is unmaintained and no longer works with python3.12. It is therefore replaced with an active fork called jinjanator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

