### PR TITLE
makefile: Add vendor target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ MULTUS_SOCKET_PATH ?= "/run/multus/multus.sock"
 
 GIT_SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 
-.PHONY: manifests
+.PHONY: manifests \
+        vendor
 
 all: build test
 
@@ -34,3 +35,7 @@ test:
 
 e2e/test:
 	$(GO) test -v -count=1 ./e2e/...
+
+vendor:
+	$(GO) mod tidy
+	$(GO) mod vendor


### PR DESCRIPTION
**What this PR does / why we need it**:
Make life simpler, add `vendor` target.
We are used to this command on them.

It will ease automation, because it aligns the the same
command on all other network repos.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

