### PR TITLE
Fix pod controller flaky unit test

### DIFF
--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pkg/cri"

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
@@ -404,7 +404,19 @@ func newDummyPodController(
 	podController.areNetAttachDefsSynched = alwaysReady
 
 	podInformerFactory.Start(stopChannel)
+	synced := podInformerFactory.WaitForCacheSync(stopChannel)
+	for v, ok := range synced {
+		if !ok {
+			fmt.Fprintf(os.Stderr, "caches failed to sync (podInformerFactory): %v", v)
+		}
+	}
 	netAttachDefInformerFactory.Start(stopChannel)
+	synced = netAttachDefInformerFactory.WaitForCacheSync(stopChannel)
+	for v, ok := range synced {
+		if !ok {
+			fmt.Fprintf(os.Stderr, "caches failed to sync (netAttachDefInformerFactory): %v", v)
+		}
+	}
 
 	controller := &dummyPodController{
 		PodNetworksController: podController,

--- a/pkg/cri/containerd/runtime_test.go
+++ b/pkg/cri/containerd/runtime_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pkg/cri/containerd/fake"

--- a/pkg/cri/crio/runtime_test.go
+++ b/pkg/cri/crio/runtime_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pkg/cri/crio/fake"


### PR DESCRIPTION
**What this PR does / why we need it**:

client-go recommends to call WaitForCacheSync after calling Start on the SharedInformerFactory.
https://pkg.go.dev/k8s.io/client-go@v0.28.4/informers#SharedInformerFactory

This fixes the flaky unit test for the pod controller.

ginkgo could be updated to its version 2 (github.com/onsi/ginkgo/v2)

**Which issue(s) this PR fixes** *
/

**Special notes for your reviewer** *(optional)*:

I am not so familiar writing controller only with client-go, usually I use [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime). So I don't really know what is done behind WaitForCacheSync except from what I could read in the documentation.

From what I observed, sometimes, handlePodUpdate is not called with the latest pod changes.

I tried to repeat the tests 100 times with this fix (using `ginkgo --repeat=100 -timeout=240s ./pkg/controller/...`), it never failed.
