### PR TITLE
e2e: make tests run serially

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -25,7 +25,7 @@ func TestDynamicNetworksControllerE2E(t *testing.T) {
 	RunSpecs(t, "Multus Dynamic Networks Controller")
 }
 
-var _ = Describe("Multus dynamic networks controller", func() {
+var _ = Describe("Multus dynamic networks controller", Serial, func() {
 	const (
 		namespace   = "ns1"
 		networkName = "tenant-network"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
We're seeing issues with the namespace deletion (new test starts while
the previous test namespace is still being deleted).
    
The `DeleteNamespace` code should ensure the namespace is gone before
the new test starts; thus, I think the tests are executing in
parallel.
    
Let's ensure they run sequentially.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

