### PR TITLE
Fix network status on failing attachement add/delete

### DIFF
--- a/pkg/annotations/dynamic-network-status.go
+++ b/pkg/annotations/dynamic-network-status.go
@@ -70,7 +70,7 @@ func NamespacedName(podNamespace string, podName string) string {
 func IndexNetworkStatus(currentPodNetworkStatus []nettypes.NetworkStatus) map[string]nettypes.NetworkStatus {
 	indexedNetworkStatus := map[string]nettypes.NetworkStatus{}
 	for i := range currentPodNetworkStatus {
-		indexedNetworkStatus[networkStatusIndexKey(currentPodNetworkStatus[i])] = currentPodNetworkStatus[i]
+		indexedNetworkStatus[NetworkStatusIndexKey(currentPodNetworkStatus[i])] = currentPodNetworkStatus[i]
 	}
 	return indexedNetworkStatus
 }
@@ -83,13 +83,13 @@ func indexNetworkStatusWithIgnorePredicate(pod *corev1.Pod, p IgnoreStatusPredic
 	indexedNetworkStatus := map[string]nettypes.NetworkStatus{}
 	for i := range currentPodNetworkStatus {
 		if !p(currentPodNetworkStatus[i]) {
-			indexedNetworkStatus[networkStatusIndexKey(currentPodNetworkStatus[i])] = currentPodNetworkStatus[i]
+			indexedNetworkStatus[NetworkStatusIndexKey(currentPodNetworkStatus[i])] = currentPodNetworkStatus[i]
 		}
 	}
 	return indexedNetworkStatus
 }
 
-func networkStatusIndexKey(networkStatus nettypes.NetworkStatus) string {
+func NetworkStatusIndexKey(networkStatus nettypes.NetworkStatus) string {
 	return fmt.Sprintf(
 		"%s/%s",
 		networkStatus.Name,

--- a/pkg/annotations/network-selection-elements.go
+++ b/pkg/annotations/network-selection-elements.go
@@ -137,17 +137,28 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 }
 
 func IndexPodNetworkSelectionElements(pod *corev1.Pod) map[string]nadv1.NetworkSelectionElement {
-	currentPodNetworkSelectionElements, err := networkSelectionElements(pod.GetAnnotations(), pod.GetNamespace())
+	currentPodNetworkSelectionElements, err := PodNetworkSelectionElements(pod)
 	if err != nil {
-		klog.Errorf("could not read pod's network selection elements: %v", *pod)
 		return map[string]nadv1.NetworkSelectionElement{}
 	}
+	return IndexNetworkSelectionElements(currentPodNetworkSelectionElements)
+}
+
+func IndexNetworkSelectionElements(networkSelectionElements []nadv1.NetworkSelectionElement) map[string]nadv1.NetworkSelectionElement {
 	indexedNetworkSelectionElements := make(map[string]nadv1.NetworkSelectionElement)
-	for k := range currentPodNetworkSelectionElements {
-		netSelectionElement := currentPodNetworkSelectionElements[k]
+	for k := range networkSelectionElements {
+		netSelectionElement := networkSelectionElements[k]
 		indexedNetworkSelectionElements[NetworkSelectionElementIndexKey(netSelectionElement)] = netSelectionElement
 	}
 	return indexedNetworkSelectionElements
+}
+
+func PodNetworkSelectionElements(pod *corev1.Pod) ([]nadv1.NetworkSelectionElement, error) {
+	currentPodNetworkSelectionElements, err := networkSelectionElements(pod.GetAnnotations(), pod.GetNamespace())
+	if err != nil {
+		return nil, fmt.Errorf("could not read pod's network selection elements %s: %v", podNameAndNs(pod), err)
+	}
+	return currentPodNetworkSelectionElements, nil
 }
 
 func networkSelectionElements(podAnnotations map[string]string, podNamespace string) ([]nadv1.NetworkSelectionElement, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When adding 2 attachements and the second was failing, the status was not reported in the annotation. Same behavior was happening for deletion.
This is now fixed, and events are also reported in case of failure on adding/deleting annotations.
   
The order in which attachements are handled is now deterministic to fulfill some special use cases (e.g. macvlan attachement + vlan attachement based on the macvlan) and to improve testing and troubleshooting.
This behavior should be now locked with the pod controller unit tests.

The default network status must be ignored and be kept. A unit test has been added to cover this case.

**Which issue(s) this PR fixes**:
Fixes #194 (3.)

**Special notes for your reviewer** *(optional)*:

