### PR TITLE
e2e job: load image in kind

### DIFF
--- a/hack/e2e-kind-cluster-setup.sh
+++ b/hack/e2e-kind-cluster-setup.sh
@@ -4,7 +4,7 @@ set -xe
 CNI_VERSION=${CNI_VERSION:-0.4.0}
 OCI_BIN=${OCI_BIN:-docker}
 IMG_REGISTRY=${IMAGE_REGISTRY:-localhost:5000/k8snetworkplumbingwg}
-IMG_TAG="latest"
+IMG_TAG="e2e"
 
 start_registry_container() {
     pushd multus-cni
@@ -25,7 +25,7 @@ setup_cluster() {
 push_local_image() {
     OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" IMAGE_TAG="$IMG_TAG" make manifests
     OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" IMAGE_TAG="$IMG_TAG" make img-build
-    "$OCI_BIN" push "$IMG_REGISTRY/multus-dynamic-networks-controller:$IMG_TAG"
+    kind load docker-image $IMG_REGISTRY/multus-dynamic-networks-controller:$IMG_TAG
 }
 
 cleanup() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The Multus e2e environment is no longer using the local registry. The image is now loaded. The tag has been set to e2e so there is no conflict if the ImagePullPolicy is not set

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer** *(optional)*:

