### PR TITLE
Remove softlink as file exists

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,7 +16,6 @@ jobs:
 
     - run: |
         pip3 install --user --upgrade jinjanator
-        ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
         j2 --version
 
     - uses: actions/checkout@v3

--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -16,7 +16,6 @@ jobs:
 
       - run: |
           pip3 install --user --upgrade jinjanator
-          ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
           j2 --version
 
       - uses: actions/checkout@v3

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -56,7 +56,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           pip3 install --user --upgrade jinjanator
-          ln -s ~/.local/bin/jinjanate ~/.local/bin/j2
           j2 --version
 
       - name: Template release manifests


### PR DESCRIPTION
**What this PR does / why we need it**:
softlink removed because file already exists 
https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/actions/runs/11035289947/job/30650904671
was introduced as part of https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pull/183


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

