### PR TITLE
Add multiarch image build support using github actions.

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -7,9 +7,10 @@ on:
       - 'v*.*.*'
 env:
   image-push-owner: 'k8snetworkplumbingwg'
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
 jobs:
-  push-amd64:
-    name: Image push/amd64
+  push-image:
+    name: Image push
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -36,8 +37,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest-amd64
+          tags: ghcr.io/${{ github.repository }}:latest
           file: images/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
           build-args: |
             git_sha=${{ env.git_commit_hash }}
 
@@ -49,6 +51,7 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{  github.ref_name }}
           file: images/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
           build-args: |
             git_sha=${{ env.git_commit_hash }}
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,11 +1,16 @@
-FROM quay.io/projectquay/golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.22 AS builder
 ENV GOPATH=/go
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS:-linux}
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
 RUN mkdir -p $GOPATH/src/github.com/maiqueb/multus-dynamic-networks-controller
 WORKDIR $GOPATH/src/github.com/maiqueb/multus-dynamic-networks-controller
 COPY . .
-RUN GOOS=linux CGO_ENABLED=0 go build -o /dynamic-networks-controller ./cmd/dynamic-networks-controller
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o /dynamic-networks-controller ./cmd/dynamic-networks-controller
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/${TARGETARCH} registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /dynamic-networks-controller /dynamic-networks-controller
 
 ARG git_url=https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller.git


### PR DESCRIPTION
These changes enable the building of the Multus Dynamic CNI image for multiple platforms (amd64, arm64, s390x) using github actions.

**What this PR does / why we need it**:
The upstream image of the Multus Dynamic Networks Controller CNI ([link](https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/pkgs/container/multus-dynamic-networks-controller)) currently supports only the amd64 architecture. These changes extend multi-platform support to include arm64 and s390x architectures, enhancing the compatibility of the Multus Dynamic Networks Controller image across a broader range of systems.

Cross-compilation is performed in the builder image using the TARGETOS and TARGETARCH build arguments, which specify the target OS and architecture. These arguments are automatically configured by the multi-architecture build process using docker buildx

More information: [[Docker Buildx Documentation](https://docs.docker.com/build/building/multi-platform/)](https://docs.docker.com/build/building/multi-platform/)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #264 

**Special notes for your reviewer** *(optional)*:

