### PR TITLE
ginkgo: rely on DeferCleanup

### DIFF
--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -25,10 +25,9 @@ var _ = Describe("The dynamic network attachment configuration", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(configurationDir, allowAllPermissions)).To(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(os.RemoveAll(configurationDir)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(configurationDir)).To(Succeed())
+		})
 	})
 
 	When("a valid configuration file is provided", func() {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -61,10 +61,9 @@ var _ = Describe("Dynamic Attachment controller", func() {
 			Expect(os.WriteFile(
 				path.Join(cniConfigDir, multusConfigPath),
 				[]byte(dummyMultusConfig()), configFilePermissions)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			Expect(os.RemoveAll(cniConfigDir)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(os.RemoveAll(cniConfigDir)).To(Succeed())
+			})
 		})
 
 		Context("with an existing running pod", func() {
@@ -121,12 +120,9 @@ var _ = Describe("Dynamic Attachment controller", func() {
 					netAttachDef(networkToAdd1, namespace, dummyNetSpec(networkToAdd1, cniVersion)))
 				Expect(err).NotTo(HaveOccurred())
 				stopChannel = make(chan struct{})
+				DeferCleanup(func() { close(stopChannel) })
 				const maxEvents = 5
 				eventRecorder = record.NewFakeRecorder(maxEvents)
-			})
-
-			AfterEach(func() {
-				close(stopChannel)
 			})
 
 			JustBeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Using defercleanup instead of `AfterEach` blocks is more idiomatic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

