### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/manifests/crio-dynamic-networks-controller.yaml
+++ b/manifests/crio-dynamic-networks-controller.yaml
@@ -129,6 +129,7 @@ spec:
               mountPath: /host/run/multus/multus.sock
             - name: cri-socket
               mountPath: /host/run/crio/crio.sock
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       volumes:
         - name: dynamic-networks-controller-config-dir

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -129,6 +129,7 @@ spec:
               mountPath: /host/run/multus/multus.sock
             - name: cri-socket
               mountPath: /host/run/containerd/containerd.sock
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       volumes:
         - name: dynamic-networks-controller-config-dir

--- a/templates/dynamic-networks-controller.yaml.j2
+++ b/templates/dynamic-networks-controller.yaml.j2
@@ -129,6 +129,7 @@ spec:
               mountPath: /host{{ MULTUS_SOCKET_PATH }}
             - name: cri-socket
               mountPath: /host{{ CRI_SOCKET_PATH }}
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       volumes:
         - name: dynamic-networks-controller-config-dir


### PR DESCRIPTION
To comply with best practices, all the containers in all the pods, must set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

