### PR TITLE
build: bump Go version to 1.25.9

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,9 +29,9 @@ jobs:
       run: time make build
 
     - name: Linters
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.54.2
+        version: v2.11.4
         args: --timeout 3m --verbose cmd/... pkg/...
 
     - name: Check vendors

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.22.10
+        go-version: 1.25.9
 
     - name: Build
       run: time make build

--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.25.9
 
       - name: Setup kind cluster
         run: hack/e2e-kind-cluster-setup.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,61 +1,7 @@
-run:
-  skip-dirs:
-    - pkg/annotations
-
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 110
-    statements: 60
-    ignore-comments: true
-  gci:
-    local-prefixes: github.com/maiqueb/multus-dynamic-networks-controller
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - paramTypeCombine
-      - whyNoLint
-      - wrapperFunc
-    settings:
-      hugeParam:
-        sizeThreshold: 1024
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/maiqueb/multus-dynamic-networks-controller
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
-  govet:
-    check-shadowing: true
-  lll:
-    line-length: 140
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
@@ -67,12 +13,9 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - goheader
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -82,9 +25,59 @@ linters:
     - nolintlint
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 110
+      statements: 60
+      ignore-comments: true
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - octalLiteral
+        - paramTypeCombine
+        - whyNoLint
+        - wrapperFunc
+      settings:
+        hugeParam:
+          sizeThreshold: 1024
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false
+      require-explanation: false
+      require-specific: false
+  exclusions:
+    paths:
+      - pkg/annotations
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/maiqueb/multus-dynamic-networks-controller

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller
 
-go 1.22.0
+go 1.25
 
-toolchain go1.22.10
+toolchain go1.25.9
 
 require (
 	github.com/containernetworking/cni v1.2.3

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.25 AS builder
 ENV GOPATH=/go
 ARG TARGETOS
 ARG TARGETARCH

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -24,7 +25,7 @@ type Multus struct {
 
 // LoadConfig loads the configuration for the multus daemon
 func LoadConfig(configPath string) (*Multus, error) {
-	config, err := os.ReadFile(configPath)
+	config, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the config file's contents: %w", err)
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -290,11 +290,12 @@ func (pnc *PodNetworksController) handleDynamicInterfaceRequest(
 	dynamicAttachmentRequest *DynamicAttachmentRequest,
 ) ([]annotations.AttachmentResult, error) {
 	klog.Infof("handleDynamicInterfaceRequest: read from queue: %v", dynamicAttachmentRequest)
-	if dynamicAttachmentRequest.Type == add {
+	switch dynamicAttachmentRequest.Type {
+	case add:
 		return pnc.addNetworks(dynamicAttachmentRequest)
-	} else if dynamicAttachmentRequest.Type == remove {
+	case remove:
 		return pnc.removeNetworks(dynamicAttachmentRequest)
-	} else {
+	default:
 		klog.Infof("very weird attachment request: %+v", dynamicAttachmentRequest)
 	}
 	klog.Infof("handleDynamicInterfaceRequest: exited & successfully processed: %v", dynamicAttachmentRequest)

--- a/pkg/multuscni/client.go
+++ b/pkg/multuscni/client.go
@@ -38,7 +38,7 @@ func NewClient(socketPath string) *HTTPClient {
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network string, addr string) (net.Conn, error) {
-					return net.Dial("unix", socketPath)
+					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Go version to 1.25.9 since 1.22 is out of support.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

